### PR TITLE
Avro converter handles tombstone messages

### DIFF
--- a/avro-converter/src/main/java/com/bridg/connect/avro/AvroConverter.java
+++ b/avro-converter/src/main/java/com/bridg/connect/avro/AvroConverter.java
@@ -30,6 +30,7 @@ import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.errors.DataException;
 import org.apache.kafka.connect.storage.Converter;
 
+import java.util.Arrays;
 import java.util.Map;
 
 /**
@@ -43,6 +44,7 @@ public class AvroConverter implements Converter {
 
   private boolean isKey;
   private AvroData avroData;
+  private byte[] tombstone = {0x0};
 
   public AvroConverter() {
   }
@@ -78,18 +80,23 @@ public class AvroConverter implements Converter {
 
   @Override
   public SchemaAndValue toConnectData(String topic, byte[] value) {
-    try {
-      GenericContainer deserialized = deserializer.deserialize(topic, isKey, value);
-      if (deserialized == null) {
-        return SchemaAndValue.NULL;
-      } else if (deserialized instanceof IndexedRecord) {
-        return avroData.toConnectData(deserialized.getSchema(), deserialized);
-      } else if (deserialized instanceof NonRecordContainer) {
-        return avroData.toConnectData(deserialized.getSchema(), ((NonRecordContainer) deserialized).getValue());
+    // If we have a null byte, handle as a tombstone
+    if (value == null || Arrays.equals(value, tombstone)) {
+      return SchemaAndValue.NULL;
+    } else {
+      try {
+        GenericContainer deserialized = deserializer.deserialize(topic, isKey, value);
+        if (deserialized == null) {
+          return SchemaAndValue.NULL;
+        } else if (deserialized instanceof IndexedRecord) {
+          return avroData.toConnectData(deserialized.getSchema(), deserialized);
+        } else if (deserialized instanceof NonRecordContainer) {
+          return avroData.toConnectData(deserialized.getSchema(), ((NonRecordContainer) deserialized).getValue());
+        }
+        throw new DataException("Unsupported type returned during deserialization of topic %s ".format(topic));
+      } catch (SerializationException e) {
+        throw new DataException("Failed to deserialize data for topic %s to Avro: ".format(topic), e);
       }
-      throw new DataException("Unsupported type returned during deserialization of topic %s ".format(topic));
-    } catch (SerializationException e) {
-      throw new DataException("Failed to deserialize data for topic %s to Avro: ".format(topic), e);
     }
   }
 

--- a/avro-converter/src/main/java/com/bridg/connect/avro/AvroConverter.java
+++ b/avro-converter/src/main/java/com/bridg/connect/avro/AvroConverter.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-package io.confluent.connect.avro;
+package com.bridg.connect.avro;
 
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;

--- a/avro-converter/src/main/java/com/bridg/connect/avro/AvroConverterConfig.java
+++ b/avro-converter/src/main/java/com/bridg/connect/avro/AvroConverterConfig.java
@@ -1,4 +1,4 @@
-package io.confluent.connect.avro;
+package com.bridg.connect.avro;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/avro-converter/src/main/java/com/bridg/connect/avro/AvroData.java
+++ b/avro-converter/src/main/java/com/bridg/connect/avro/AvroData.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-package io.confluent.connect.avro;
+package com.bridg.connect.avro;
 
 import io.confluent.kafka.serializers.AbstractKafkaAvroDeserializer;
 import io.confluent.kafka.serializers.NonRecordContainer;

--- a/avro-converter/src/main/java/com/bridg/connect/avro/AvroDataConfig.java
+++ b/avro-converter/src/main/java/com/bridg/connect/avro/AvroDataConfig.java
@@ -1,4 +1,4 @@
-package io.confluent.connect.avro;
+package com.bridg.connect.avro;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/avro-converter/src/test/java/com/bridg/connect/avro/AdditionalAvroDataTest.java
+++ b/avro-converter/src/test/java/com/bridg/connect/avro/AdditionalAvroDataTest.java
@@ -1,4 +1,4 @@
-package io.confluent.connect.avro;
+package com.bridg.connect.avro;
 
 import java.io.File;
 import java.io.IOException;
@@ -100,7 +100,7 @@ public class AdditionalAvroDataTest
            "{"
            + "  \"type\" : \"record\","
            + "  \"name\" : \"MyObjectToPersist\","
-           + "  \"namespace\" : \"io.confluent.connect.avro.AdditionalAvroDataTest$\","
+           + "  \"namespace\" : \"com.bridg.connect.avro.AdditionalAvroDataTest$\","
            + "  \"fields\" : [ {"
            + "    \"name\" : \"obj\","
            + "    \"type\" : [ \"null\", {"

--- a/avro-converter/src/test/java/com/bridg/connect/avro/AvroConverterTest.java
+++ b/avro-converter/src/test/java/com/bridg/connect/avro/AvroConverterTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-package io.confluent.connect.avro;
+package com.bridg.connect.avro;
 
 import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaAndValue;

--- a/avro-converter/src/test/java/com/bridg/connect/avro/AvroDataTest.java
+++ b/avro-converter/src/test/java/com/bridg/connect/avro/AvroDataTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  **/
 
-package io.confluent.connect.avro;
+package com.bridg.connect.avro;
 
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -51,8 +51,8 @@ import java.util.TimeZone;
 
 import io.confluent.kafka.serializers.NonRecordContainer;
 
-import static io.confluent.connect.avro.AvroData.AVRO_TYPE_ENUM;
-import static io.confluent.connect.avro.AvroData.CONNECT_ENUM_DOC_PROP;
+import static com.bridg.connect.avro.AvroData.AVRO_TYPE_ENUM;
+import static com.bridg.connect.avro.AvroData.CONNECT_ENUM_DOC_PROP;
 import static org.junit.Assert.*;
 
 public class AvroDataTest {


### PR DESCRIPTION
Checks for the null message before attempting to deserialize it. If the message value is null then we return a null SchemaAndValue.

This will prevent errors at the converter stage which run before the single message transformation chain is applied.